### PR TITLE
refactor : GET /circular/location API의 response body 구조 변경

### DIFF
--- a/Backend/shattlebus/circular/views.py
+++ b/Backend/shattlebus/circular/views.py
@@ -17,6 +17,7 @@ class UpdateCircularBusLocationView(View):
 
         num_buses = len(running_bus_list)
         response['num_buses_running'] = num_buses
+        bus_lists = []
 
         for i in range(num_buses):
             bus = running_bus_list[i]
@@ -29,6 +30,8 @@ class UpdateCircularBusLocationView(View):
                         "is_tracked": bus['is_tracked']
                         }
 
-            response[i] = bus_data
+            bus_lists.append(bus_data)
+
+        response['buses'] = bus_lists
 
         return HttpResponse(json.dumps(response))


### PR DESCRIPTION
## ✨ PR 제목: refactor : GET /circular/location API의 response body 구조 변경
### ✨ 관련 task ID + description in schedule sheet
추가 task 입니다

### ✨ 작업 내용
- 기존 API의 Response Body의 구조 변경

### ✨ 코드에 특이점 있다면 설명
프런트 쪽과 합의 후에 Response Body 구조 변경했습니다
기존) 현재 운행 중인 버스에 대한 정보를 담은 dictionary를 각각의 id를 key로 하는 dictionary에 넣음
수정 후) 현재 운행 중인 버스에 대한 정보를 담은 dictionary를 하나의 list에 담아, 해당 list를 큰 dictionary에 넣음

### ✨ 작성한 레퍼런스 or 에러 공유 페이지 링크
1. 
2. 

### ✨ 스크린샷 또는 GIFs (만약 frontend UI가 바뀌었다면)  
