### PR TITLE
fix : 현재시각에 배차간격을 더해서 다음 버스 도착 시각 잡기 & 10명 이하/80명 이상 특수 case 분기

### DIFF
--- a/Backend/shattlebus/dropoff/views.py
+++ b/Backend/shattlebus/dropoff/views.py
@@ -47,6 +47,14 @@ class RetrieveWaitingTimeView(View):
     def get_waiting_data(self, num_people_waiting, updated_at_kr):
         num_needed_bus = (num_people_waiting // MAX_NUM_OF_PEOPLE) + 1
         waiting_time = self.get_waiting_time(num_needed_bus)
+
+        if num_people_waiting <= 10:
+            num_people_waiting = 10
+            num_needed_bus = 1
+        elif num_people_waiting >= 80:
+            num_people_waiting = 80
+            num_needed_bus = 3
+
         waiting_data = {
             "num_waiting_people": num_people_waiting,
             "waiting_time": waiting_time,
@@ -81,13 +89,13 @@ class RetrieveWaitingTimeView(View):
             minute_next_bus = 0
         elif 7 <= hour < 8:
             hour_next_bus = 7
-            minute_next_bus = ((minute // 15) + 1) * 15
+            minute_next_bus = minute + 15
         elif 11 <= hour < 15:
             hour_next_bus = hour
-            minute_next_bus = ((minute // 10) + 1) * 10
+            minute_next_bus = minute + 10
         else:
             hour_next_bus = hour
-            minute_next_bus = ((minute // 5) + 1) * 5
+            minute_next_bus = minute + 5
 
         if minute_next_bus >= 60:
             hour_next_bus += 1


### PR DESCRIPTION
## ✨ PR 제목: 
### ✨ 관련 task ID + description in schedule sheet
P7 Backend refactoring - dropoff (waiting time 구하는 로직 변경)

### ✨ 작업 내용
- [x] 저번에 상의했던 대로 현재 시각에 배차 간격을 더하는 방식으로 대기 시간 계산
- [x] ML에서 받은 인원이 10명 이하일 때는 10으로, 80명 이상일 때는 80으로 프런트에 주기

### ✨ 코드에 특이점 있다면 설명


### ✨ 작성한 레퍼런스 or 에러 공유 페이지 링크


### ✨ 스크린샷 또는 GIFs (만약 frontend UI가 바뀌었다면)  